### PR TITLE
Init LPT before Network to fix PLIP mode.

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -1071,10 +1071,12 @@ pc_reset_hard_init(void)
     /* Reset and reconfigure the Sound Card layer. */
     sound_card_reset();
 
+    /* Initialize parallel devices. */
+    /* note: PLIP LPT side has to be initialized before the network side */
+    lpt_devices_init();
+
     /* Reset and reconfigure the Network Card layer. */
     network_reset();
-
-    lpt_devices_init();
 
     /* Reset and reconfigure the serial ports. */
     serial_standalone_init();


### PR DESCRIPTION
Summary
=======
Fix crash when using PLIP networking - attempt to fix #3699.
I've swapped the order of initialization of the LPT and network modules to ensure the network module can access the LPT instance and fill in the card details.
I hope there are no side-effects to this change.

Checklist
=========
* [ ] Closes #3699
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
